### PR TITLE
Fix construction of BIP34 coinbase.

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -592,6 +592,11 @@ static bool gbt_work_decode( const json_t *val, struct work *work )
       /* BIP 34: height in coinbase */
       for ( n = work->height; n; n >>= 8 )
          cbtx[cbtx_size++] = n & 0xff;
+         /* If the last byte pushed is >= 0x80, then we need to add
+                   another zero byte to signal that the block height is a
+                   positive number.  */
+                if (cbtx[cbtx_size - 1] & 0x80)
+                        cbtx[cbtx_size++] = 0;
       cbtx[42] = cbtx_size - 43;
       cbtx[41] = cbtx_size - 42; /* scriptsig length */
       le32enc( (uint32_t *)( cbtx+cbtx_size ), 0xffffffff ); /* sequence */


### PR DESCRIPTION
tpruvot/cpuminer-multi#25

The expected coinbase for BIP34 blocks is constructed by serialising a script with the block height as integer. In the end, this leads to the code in CScriptNum::serialize in the Bitcoin Core codebase.

Specifically, for positive numbers (as in the case of a block height), the rule [1] is that another zero byte has to be pushed in case the last byte had the highest bit set (since that bit is used to indicate the sign).

Note that even with this fix, there is still a bug for heights up to 16 - pushing these integers onto scripts is special cased in Bitcoin, but it seems unclear how worthwhile a special fix for just these few blocks is.

[1] https://github.com/bitcoin/bitcoin/blob/e117cfe45eee9169409e74a44ef4a866be25bc35/src/script/script.h#L351

***

the issue was:

-printtoconsole:
```js
2018-12-02 01:57:37 dnsseed thread exit
2018-12-02 01:57:42 ERROR: AcceptBlock: bad-cb-height, block height mismatch in coinbase (code 16)
2018-12-02 01:57:42 ERROR: ProcessNewBlock: AcceptBlock FAILED (block height mismatch in coinbase)
```

cpuminer
```js
[2018-12-02 11:10:36] Rejected 1/1 (100.0%), 234 H, 65.99 H/s, 34C
[2018-12-02 11:10:36] reject reason: bad-cb-height
```